### PR TITLE
Fix const-related error on dialog_format

### DIFF
--- a/easyDialog.inc
+++ b/easyDialog.inc
@@ -39,7 +39,8 @@ static
 forward OnDialogPerformed(playerid, const dialog[], response, success);
 
 forward @dialog_format(); @dialog_format() {
-	format("", 0, "");
+	new emptyString[2] = '\1';
+	format(emptyString, 2, emptyString);
 }
 
 forward Dialog_IsOpened(playerid);

--- a/easyDialog.inc
+++ b/easyDialog.inc
@@ -39,8 +39,8 @@ static
 forward OnDialogPerformed(playerid, const dialog[], response, success);
 
 forward @dialog_format(); @dialog_format() {
-	new emptyString[2] = '\1';
-	format(emptyString, 2, emptyString);
+	new emptyString[] = '\1';
+	format(emptyString, sizeof(emptyString), emptyString);
 }
 
 forward Dialog_IsOpened(playerid);


### PR DESCRIPTION
Seems like with latest compiler (3.10.10) is giving the errors, so patching it by simply adding an empty string variable instead to hides the warning.